### PR TITLE
Group Updates

### DIFF
--- a/fixtures/terraform.tfstate
+++ b/fixtures/terraform.tfstate
@@ -85,6 +85,45 @@
                     },
                     "deposed": [],
                     "provider": "provider.ansible"
+                },
+                "ansible_host.host_3": {
+                    "type": "ansible_host",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "host_3",
+                        "attributes": {
+                            "groups.#": "1",
+                            "groups.0": "group_3",
+                            "id": "host_3",
+                            "inventory_hostname": "host_3",
+                            "vars.%": "3",
+                            "vars.ansible_host": "1.2.3.6",
+                            "vars.ansible_user": "ubuntu"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.ansible"
+                },
+                "ansible_host.host_4": {
+                    "type": "ansible_host",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "host_4",
+                        "attributes": {
+                            "groups.#": "0",
+                            "id": "host_4",
+                            "inventory_hostname": "host_4",
+                            "vars.%": "3",
+                            "vars.ansible_host": "1.2.3.7",
+                            "vars.ansible_user": "ubuntu"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.ansible"
                 }
             },
             "depends_on": []

--- a/main.go
+++ b/main.go
@@ -35,6 +35,11 @@ func main() {
 			errAndExit(err)
 		}
 
+		if s == nil {
+			fmt.Println("No state was found")
+			os.Exit(1)
+		}
+
 		j, err := s.ToJSON()
 		if err != nil {
 			errAndExit(err)

--- a/state.go
+++ b/state.go
@@ -15,6 +15,7 @@ type State struct {
 	Modules []Module `json:"modules"`
 }
 
+// GetGroups will return all ansible_group resources.
 func (r State) GetGroups() ([]string, error) {
 	var groups []string
 
@@ -30,6 +31,23 @@ func (r State) GetGroups() ([]string, error) {
 	return groups, nil
 }
 
+// GetHosts will return all ansible_group resources.
+func (r State) GetHosts() ([]string, error) {
+	var hosts []string
+
+	for _, m := range r.Modules {
+		for _, resource := range m.Resources {
+			if resource.Type == "ansible_host" {
+				hosts = append(hosts, resource.Primary.ID)
+			}
+		}
+	}
+
+	sort.Strings(hosts)
+	return hosts, nil
+}
+
+// GetGroup will find and return a specific ansible_group resource.
 func (r State) GetGroup(group string) (*Resource, error) {
 	for _, m := range r.Modules {
 		for _, resource := range m.Resources {
@@ -44,6 +62,8 @@ func (r State) GetGroup(group string) (*Resource, error) {
 	return nil, fmt.Errorf("Unable to find group %s", group)
 }
 
+// GetChildrenForGroup will return the "children" members of an
+// ansible_group resource.
 func (r State) GetChildrenForGroup(group string) ([]string, error) {
 	var children []string
 
@@ -65,6 +85,8 @@ func (r State) GetChildrenForGroup(group string) ([]string, error) {
 	return children, nil
 }
 
+// GetVarsForGroup will return the variables defined in an ansible_group
+// resource.
 func (r State) GetVarsForGroup(group string) (map[string]interface{}, error) {
 	vars := make(map[string]interface{})
 
@@ -89,6 +111,8 @@ func (r State) GetVarsForGroup(group string) (map[string]interface{}, error) {
 	return vars, nil
 }
 
+// GetHostsForGroup will return the hosts in a specific ansible_group
+// resource.
 func (r State) GetHostsForGroup(group string) ([]string, error) {
 	var hosts []string
 
@@ -110,6 +134,7 @@ func (r State) GetHostsForGroup(group string) ([]string, error) {
 	return hosts, nil
 }
 
+// GetHost will return a specific ansible_host.
 func (r State) GetHost(host string) (*Resource, error) {
 	for _, m := range r.Modules {
 		for _, resource := range m.Resources {
@@ -124,6 +149,32 @@ func (r State) GetHost(host string) (*Resource, error) {
 	return nil, fmt.Errorf("Unable to find host %s", host)
 }
 
+// GetGroupsForHost will return the groups defined in an ansible_host resource.
+func (r State) GetGroupsForHost(host string) ([]string, error) {
+	groups := []string{}
+
+	resource, err := r.GetHost(host)
+	if err != nil {
+		return nil, err
+	}
+
+	for attrName, attr := range resource.Primary.Attributes {
+		if strings.HasPrefix(attrName, "groups.") {
+			if attrName == "groups.#" {
+				continue
+			}
+
+			pieces := strings.SplitN(attrName, ".", 2)
+			if len(pieces) == 2 {
+				groups = append(groups, attr)
+			}
+		}
+	}
+
+	return groups, nil
+}
+
+// GetVarsForHost will return the variables defined in an ansible_host resource.
 func (r State) GetVarsForHost(host string) (map[string]interface{}, error) {
 	vars := make(map[string]interface{})
 
@@ -152,12 +203,15 @@ func (r State) BuildInventory() (map[string]interface{}, error) {
 	inv := make(map[string]interface{})
 	meta := make(map[string]interface{})
 	hostvars := make(map[string]interface{})
+	allHosts := []string{}
 
+	// Get all ansible_group resources.
 	groups, err := r.GetGroups()
 	if err != nil {
 		return nil, err
 	}
 
+	// For each ansible_group defined...
 	for _, group := range groups {
 		g := make(map[string]interface{})
 		hosts, err := r.GetHostsForGroup(group)
@@ -165,40 +219,124 @@ func (r State) BuildInventory() (map[string]interface{}, error) {
 			return nil, err
 		}
 
+		// Get the children of the group.
 		children, err := r.GetChildrenForGroup(group)
 		if err != nil {
 			return nil, err
 		}
 
+		// Get any variables for the group.
 		vars, err := r.GetVarsForGroup(group)
 		if err != nil {
 			return nil, err
 		}
 
+		// Set the hosts.
 		if len(hosts) > 0 {
 			g["hosts"] = hosts
 		}
 
+		// Set the children.
 		if len(children) > 0 {
 			g["children"] = children
 		}
 
+		// Set the variables.
 		g["vars"] = vars
 		inv[group] = g
+	}
 
-		for _, host := range hosts {
-			vars, err := r.GetVarsForHost(host)
-			if err != nil {
-				return nil, err
-			}
+	// Now that we've accounted for all explicitly defined
+	// groups, let's find any groups which were implicitly
+	// defined. These are ansible_host resources with group
+	// memberships of groups that have no explicit
+	// ansible_group resource.
+	//
+	// In addition, create an "ungrouped" group which will
+	// contain hosts that have no group membership.
+	var ungrouped []string
 
-			hostvars[host] = vars
+	// Get all ansible_host resources defined.
+	hosts, err := r.GetHosts()
+	if err != nil {
+		return nil, err
+	}
+
+	// For each host...
+	for _, host := range hosts {
+		// Add the host to the set of all hosts.
+		allHosts = append(allHosts, host)
+
+		// Get any variable defined and set it in the inventory.
+		vars, err := r.GetVarsForHost(host)
+		if err != nil {
+			return nil, err
 		}
 
+		hostvars[host] = vars
+
+		// Find all groups that the host is a part of.
+		groups, err := r.GetGroupsForHost(host)
+		if err != nil {
+			return nil, err
+		}
+
+		// If no groups were defined, add the host to the "ungrouped" group.
+		if len(groups) == 0 {
+			ungrouped = append(ungrouped, host)
+		}
+
+		// For each group defined in the host...
+		for _, group := range groups {
+			// Check and see if this group has already been accounted for.
+			// If it has, check for the host membership.
+			if v, ok := inv[group]; ok {
+				groupInventory := v.(map[string]interface{})
+				if hostInventory, ok := groupInventory["hosts"].([]string); ok {
+					var found bool
+					for _, h := range hostInventory {
+						if h == host {
+							found = true
+						}
+					}
+
+					if !found {
+						hostInventory = append(hostInventory, host)
+					}
+				}
+			} else {
+				// if the group wasn't already accounted for, do it now.
+				inv[group] = map[string]interface{}{
+					"hosts": []string{host},
+					"vars":  map[string]interface{}{},
+				}
+			}
+		}
+	}
+
+	// If there are any "ungrouped" hosts, create an inventory entry
+	// for "ungrouped".
+	if len(ungrouped) > 0 {
+		inv["ungrouped"] = map[string]interface{}{
+			"hosts": ungrouped,
+			"vars":  map[string]interface{}{},
+		}
+	}
+
+	// Create an "all" group if one was not defined.
+	if _, ok := inv["all"]; !ok {
+		sort.Strings(allHosts)
+		all := map[string]interface{}{
+			"hosts": allHosts,
+			"vars":  map[string]interface{}{},
+		}
+
+		inv["all"] = all
 	}
 
 	meta["hostvars"] = hostvars
 	inv["_meta"] = meta
+
 	return inv, nil
 }
 
@@ -248,6 +386,11 @@ func getState(path string) (*State, error) {
 	b, err := ioutil.ReadAll(&out)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading output of `terraform state pull`: %s\n", err)
+	}
+
+	// If there was no output, return nil and no error
+	if string(b) == "" {
+		return nil, nil
 	}
 
 	if string(b[0]) == "o" && string(b[1]) == ":" {

--- a/state_test.go
+++ b/state_test.go
@@ -42,6 +42,35 @@ var expectedState = State{
 						},
 					},
 				},
+				"ansible_host.host_3": Resource{
+					Type: "ansible_host",
+					Primary: Primary{
+						ID: "host_3",
+						Attributes: map[string]string{
+							"id":                 "host_3",
+							"inventory_hostname": "host_3",
+							"groups.#":           "1",
+							"groups.0":           "group_3",
+							"vars.%":             "3",
+							"vars.ansible_host":  "1.2.3.6",
+							"vars.ansible_user":  "ubuntu",
+						},
+					},
+				},
+				"ansible_host.host_4": Resource{
+					Type: "ansible_host",
+					Primary: Primary{
+						ID: "host_4",
+						Attributes: map[string]string{
+							"id":                 "host_4",
+							"inventory_hostname": "host_4",
+							"groups.#":           "0",
+							"vars.%":             "3",
+							"vars.ansible_host":  "1.2.3.7",
+							"vars.ansible_user":  "ubuntu",
+						},
+					},
+				},
 				"ansible_group.group_1": Resource{
 					Type: "ansible_group",
 					Primary: Primary{
@@ -72,6 +101,14 @@ var expectedState = State{
 }
 
 var expectedInventory = map[string]interface{}{
+	"all": map[string]interface{}{
+		"hosts": []string{"host_1", "host_2", "host_3", "host_4"},
+		"vars":  map[string]interface{}{},
+	},
+	"ungrouped": map[string]interface{}{
+		"hosts": []string{"host_4"},
+		"vars":  map[string]interface{}{},
+	},
 	"group_1": map[string]interface{}{
 		"hosts":    []string{"host_1", "host_2"},
 		"children": []string{"group_2"},
@@ -81,6 +118,10 @@ var expectedInventory = map[string]interface{}{
 	},
 	"group_2": map[string]interface{}{
 		"vars": map[string]interface{}{},
+	},
+	"group_3": map[string]interface{}{
+		"hosts": []string{"host_3"},
+		"vars":  map[string]interface{}{},
 	},
 	"_meta": map[string]interface{}{
 		"hostvars": map[string]interface{}{
@@ -93,6 +134,14 @@ var expectedInventory = map[string]interface{}{
 				"ansible_host": "1.2.3.5",
 				"ansible_user": "ubuntu",
 				"test":         "host_2",
+			},
+			"host_3": map[string]interface{}{
+				"ansible_host": "1.2.3.6",
+				"ansible_user": "ubuntu",
+			},
+			"host_4": map[string]interface{}{
+				"ansible_host": "1.2.3.7",
+				"ansible_user": "ubuntu",
 			},
 		},
 	},


### PR DESCRIPTION
This commit makes several updates for "groups":

1. Support for "implicit" groups has been added. When an ansible_host
declares that it is part of a group, but no ansible_group resource exists,
the group will automatically be created.

2. Support for an "all" group has been added.

3. Support for an "ungrouped" group has been added.

For #4 