### PR TITLE
Fix unused hostvars array when grouping hosts

### DIFF
--- a/state.go
+++ b/state.go
@@ -124,7 +124,7 @@ func BuildInventory(state State) (map[string]interface{}, error) {
 					}
 
 					if !found {
-						hostInventory = append(hostInventory, host)
+						groupInventory["hosts"] = append(hostInventory, host)
 					}
 				}
 			} else {


### PR DESCRIPTION
Currently if there is no group defined explicitly and they are defined when checking hosts, there always will be only one host in each group