### PR TITLE
Support terragrunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ If your Ansible playbooks are in a different directory than your Terraform
 resources, then set the `TF_STATE` environment variable to the location
 of the Terraform directory.
 
+If you want to use [terragrunt](https://terragrunt.gruntwork.io/) instead of
+terraform, set the `TF_TERRAGRUNT` environment variable to any non-empty
+value and set `TF_STATE` to the directory where the `terragrunt.hcl` file is
+located.
+
 Installation
 ------------
 

--- a/main.go
+++ b/main.go
@@ -12,11 +12,22 @@ import (
 )
 
 var (
-	list = flag.Bool("list", false, "list mode")
+	list    = flag.Bool("list", false, "list mode")
+	command = Terraform
+)
+
+const (
+	Terraform  = "terraform"
+	Terragrunt = "terragrunt"
 )
 
 func main() {
 	flag.Parse()
+
+	v := os.Getenv("TF_TERRAGRUNT")
+	if v != "" {
+		command = Terragrunt
+	}
 
 	if *list {
 		file := getStatePath()
@@ -69,18 +80,18 @@ func getState(path string) (State, error) {
 	var state State
 	terraformVersion := "0.12"
 
-	cmd := exec.Command("terraform", "state", "pull")
+	cmd := exec.Command(command, "state", "pull")
 	cmd.Dir = path
 	cmd.Stdout = &out
 
 	err := cmd.Run()
 	if err != nil {
-		return nil, fmt.Errorf("Error running `terraform state pull` in directory %s, %s\n", path, err)
+		return nil, fmt.Errorf("Error running `%s state pull` in directory %s, %s\n", command, path, err)
 	}
 
 	b, err := ioutil.ReadAll(&out)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading output of `terraform state pull`: %s\n", err)
+		return nil, fmt.Errorf("Error reading output of `%s state pull`: %s\n", command, err)
 	}
 
 	// If there was no output, return nil and no error


### PR DESCRIPTION
This commit adds support for using [terragrunt](https://terragrunt.gruntwork.io) with this inventory plugin.
It works by allowing users to set the `ATFI_TERRAGRUNT` environment variable to any value. When set, the `terragrunt` command is called instead of `terraform`.